### PR TITLE
Pull Request to Allow DNS on OpenVPN Reconnect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update \
     && add-apt-repository ppa:qbittorrent-team/qbittorrent-stable \
     && apt-get update \
     && apt-get install -y qbittorrent-nox openvpn curl moreutils net-tools dos2unix kmod iptables ipcalc unrar \
+    # Added some diagnostic tools for testing OpenVPN dns issues
+    && apt-get install -y tcpdump dnsutils \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add configuration and scripts

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ docker run --privileged  -d \
 |`PUID`| No | UID applied to config files and downloads |`PUID=99`|
 |`PGID`| No | GID applied to config files and downloads |`PGID=100`|
 |`UMASK`| No | GID applied to config files and downloads |`UMASK=002`|
-|`WEBUI_PORT_ENV`| No | Applies WebUI port to qBittorrents config at boot (Must change exposed ports to match)  |`WEBUI_PORT_ENV=8080`|
+|`WEBUI_PORT`| No | Applies WebUI port to qBittorrents config at boot (Must change exposed ports to match)  |`WEBUI_PORT_ENV=8080`|
 |`INCOMING_PORT_ENV`| No | Applies Incoming port to qBittorrents config at boot (Must change exposed ports to match) |`INCOMING_PORT_ENV=8999`|
 
 ## Volumes

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -141,6 +141,14 @@ IFS=',' read -ra name_server_list <<< "${NAME_SERVERS}"
 # export name_server_list so it can be used in other scripts and we don't waste cpu cycles on another readline call
 export name_server_list
 
+# Default to override of the existing resolve conf. Docker-compose adds an internal resolver at the top of the file
+# when a bridge driver network is created. It's run on loopback 127.0.0.11 and used to resolve the other containers
+# in that docker-compose network. Non-local queries are forwarded to the host upstream resolver. OpenVPN doesn't handle
+# the fail over to secondary and tertiary DNS well on ping reset so it will cause repeated failures if the nameserver
+# 127.0.0.11 isn't removed.
+# See automatic DNS resolution here: https://docs.docker.com/network/bridge/
+cat /dev/null > /etc/resolve.conf
+
 # process name servers in the list
 for name_server_item in "${name_server_list[@]}"; do
 

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -138,6 +138,9 @@ fi
 # split comma seperated string into list from NAME_SERVERS env variable
 IFS=',' read -ra name_server_list <<< "${NAME_SERVERS}"
 
+# export name_server_list so it can be used in other scripts and we don't waste cpu cycles on another readline call
+export name_server_list
+
 # process name servers in the list
 for name_server_item in "${name_server_list[@]}"; do
 

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -121,8 +121,8 @@ if [[ $VPN_ENABLED == "yes" ]]; then
 	if [[ ! -z "${NAME_SERVERS}" ]]; then
 		echo "[info] NAME_SERVERS defined as '${NAME_SERVERS}'" | ts '%Y-%m-%d %H:%M:%.S'
 	else
-		echo "[warn] NAME_SERVERS not defined (via -e NAME_SERVERS), defaulting to Google and FreeDNS name servers" | ts '%Y-%m-%d %H:%M:%.S'
-		export NAME_SERVERS="8.8.8.8,37.235.1.174,8.8.4.4,37.235.1.177"
+		echo "[warn] NAME_SERVERS not defined (via -e NAME_SERVERS), defaulting to CloudFlare and Quad9" | ts '%Y-%m-%d %H:%M:%.S'
+		export NAME_SERVERS="1.1.1.1,9.9.9.9,1.0.0.1,149.112.112.112"
 	fi
 	export VPN_OPTIONS=$(echo "${VPN_OPTIONS}" | sed -e 's~^[ \t]*~~;s~[ \t]*$~~')
 	if [[ ! -z "${VPN_OPTIONS}" ]]; then

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -147,7 +147,7 @@ export name_server_list
 # the fail over to secondary and tertiary DNS well on ping reset so it will cause repeated failures if the nameserver
 # 127.0.0.11 isn't removed.
 # See automatic DNS resolution here: https://docs.docker.com/network/bridge/
-cat /dev/null > /etc/resolve.conf
+cat /dev/null > /etc/resolv.conf
 
 # process name servers in the list
 for name_server_item in "${name_server_list[@]}"; do

--- a/qbittorrent/iptables.sh
+++ b/qbittorrent/iptables.sh
@@ -179,8 +179,10 @@ for name_server_item in "${name_server_list[@]}"; do
 	# strip whitespace from start and end of lan_network_item
 	name_server_item=$(echo "${name_server_item}" | sed -e 's~^[ \t]*~~;s~[ \t]*$~~')
 
-	iptables -A INPUT -i eth0 -s ${name_server_item}/32 -p udp --sport 53 -j ACCEPT
-	iptables -A OUTPUT -o eth0 -d ${name_server_item}/32 -p udp --dport 53 -j ACCEPT
+	# Insert rules into iptables for allowing DNS. Relaxed interface requirement as OpenVPN appears
+	# to hold the default route in docker when it's trying to reconnect. It attempts DNS in a weird way.
+	iptables -A INPUT -s ${name_server_item}/32 -p udp --sport 53 -j ACCEPT
+	iptables -A OUTPUT -d ${name_server_item}/32 -p udp --dport 53 -j ACCEPT
 
 done
 


### PR DESCRIPTION
Hi Markus,

I decided to make a pull request to fix this issue. If OpenVPN experiences a connection failure and is using a FQDN as the remote server, the current container will not allow it to perform a DNS query to look up the IP address. This creates a permanent failure of OpenVPN unless you restart the container. It's caused by the leak prevention in iptables blocking DNS queries to ${NAME_SERVERS} on eth0 after the initial OpenVPN connection.

This could allow minor DNS leakage while OpenVPN reconnects, but I think is the best compromise for tunnel reliability. Please consider merging into master.

Thanks,

PacketShepard