### PR TITLE
Add warning of possible undesired line-ending conversion when cloning in Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ Using the latest stable verison of Docker is always recommended. Support for old
 # Building the container yourself
 To build this container, clone the repository and cd into it.
 
+## Note for Windows users:
+Your Git for Windows installation may be configured to convert Unix-style line-endings (i.e. `'\n'`) to Windows-style line-endings (i.e. `"\r\n"`) by default. If this is not overridden, images built from your local repository may encounter run-time failures due to line-ending differences between Unix and Windows.
+
+To avoid this behavior, it is recommended to clone the repository with `core.autocrlf` configured as `input`:
+```
+$ git clone -c core.autocrlf=input git://github.com/MarkusMcNugen/docker-qBittorrentvpn.git
+```
+
 ## Build it:
 ```
 $ cd /repo/location/qbittorrentvpn


### PR DESCRIPTION
The last image was pushed 5 months ago to Docker Hub, and qBittorrent has since become out-of-date by a few releases. Given this, I figured I'd build my own image so I could use the latest version.

In the process, I initially encountered some run-time failures when starting the container:
> /etc/openvpn/start.sh: line 3: set: -
: invalid option,
set: usage: set [-abefhkmnptuvxBCHP] [-o option-name] [--] [arg ...],
/etc/openvpn/start.sh: line 4: $'\r': command not found,
/etc/openvpn/start.sh: line 7: $'\r': command not found,
/etc/openvpn/start.sh: line 134: syntax error near unexpected token `elif',
/etc/openvpn/start.sh: line 134: `elif [[ $VPN_ENABLED == "no" ]]; then
',

The root cause ended up being that I had Git for Windows configured to checkout text files (including this script) with Windows-style line-endings, as officially recommended for Windows users. Thankfully, this is a simple fix: checkout with Unix-style line-endings instead, preferably on a per-repository basis.

I added a quick blurb to the README instructing Windows users to clone accordingly to work around this.