### PR TITLE
Correct start.sh and documentation for use of WEBUI_PORT and INCOMING_PORT environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ $ docker run --privileged  -d \
 |`PUID`| No | UID applied to config files and downloads |`PUID=99`|
 |`PGID`| No | GID applied to config files and downloads |`PGID=100`|
 |`UMASK`| No | GID applied to config files and downloads |`UMASK=002`|
-|`WEBUI_PORT_ENV`| No | Applies WebUI port to qBittorrents config at boot (Must change exposed ports to match)  |`WEBUI_PORT_ENV=8080`|
-|`INCOMING_PORT_ENV`| No | Applies Incoming port to qBittorrents config at boot (Must change exposed ports to match) |`INCOMING_PORT_ENV=8999`|
+|`WEBUI_PORT`| No | Applies WebUI port to qBittorrents config at boot (Must change exposed ports to match)  |`WEBUI_PORT=8080`|
+|`INCOMING_PORT`| No | Applies Incoming port to qBittorrents config at boot (Must change exposed ports to match) |`INCOMING_PORT=8999`|
 
 ## Volumes
 | Volume | Required | Function | Example |
@@ -73,7 +73,7 @@ Access http://IPADDRESS:PORT from a browser on the same network.
 WebUI\CSRFProtection must be set to false in qBittorrent.conf if using an unconfigured reverse proxy or forward request within a browser. This is the default setting unless changed. This file can be found in the dockers config directory in /qBittorrent/config
 
 ## WebUI: Invalid Host header, port mismatch
-qBittorrent throws a [WebUI: Invalid Host header, port mismatch](https://github.com/qbittorrent/qBittorrent/issues/7641#issuecomment-339370794) error if you use port forwarding with bridge networking due to security features to prevent DNS rebinding attacks. If you need to run qBittorrent on different ports, instead edit the WEBUI_PORT_ENV and/or INCOMING_PORT_ENV variables AND the exposed ports to change the native ports qBittorrent uses.
+qBittorrent throws a [WebUI: Invalid Host header, port mismatch](https://github.com/qbittorrent/qBittorrent/issues/7641#issuecomment-339370794) error if you use port forwarding with bridge networking due to security features to prevent DNS rebinding attacks. If you need to run qBittorrent on different ports, instead edit the WEBUI_PORT and/or INCOMING_PORT variables AND the exposed ports to change the native ports qBittorrent uses.
 
 # How to use OpenVPN
 The container will fail to boot if `VPN_ENABLED` is set to yes or empty and a .ovpn is not present in the /config/openvpn directory. Drop a .ovpn file from your VPN provider into /config/openvpn and start the container again. You may need to edit the ovpn configuration file to load your VPN credentials from a file by setting `auth-user-pass`.

--- a/qbittorrent/start.sh
+++ b/qbittorrent/start.sh
@@ -48,7 +48,7 @@ if [ ! -z "${WEBUI_PORT}" ]; then
 		if [[ ! -z "${webui_exist}" ]]; then
 			# Get line number of WebUI Port
 			LINE_NUM=$(grep -Fn -m 1 'WebUI\Port' /config/qBittorrent/config/qBittorrent.conf | cut -d: -f 1)
-			sed -i "${LINE_NUM}s@.*@WebUI\\Port=${WEBUI_PORT}@" /config/qBittorrent/config/qBittorrent.conf
+			sed -i "${LINE_NUM}s@.*@WebUI\\\Port=${WEBUI_PORT}@" /config/qBittorrent/config/qBittorrent.conf
 		else
 			echo "WebUI\Port=${WEBUI_PORT}" >> /config/qBittorrent/config/qBittorrent.conf
 		fi

--- a/qbittorrent/start.sh
+++ b/qbittorrent/start.sh
@@ -62,7 +62,7 @@ if [ ! -z "${INCOMING_PORT}" ]; then
 		if [[ ! -z "${incoming_exist}" ]]; then
 			# Get line number of Incoming
 			LINE_NUM=$(grep -Fn -m 1 'Connection\PortRangeMin' /config/qBittorrent/config/qBittorrent.conf | cut -d: -f 1)
-			sed -i "${LINE_NUM}s@.*@Connection\\PortRangeMin=${INCOMING_PORT}@" /config/qBittorrent/config/qBittorrent.conf
+			sed -i "${LINE_NUM}s@.*@Connection\\\PortRangeMin=${INCOMING_PORT}@" /config/qBittorrent/config/qBittorrent.conf
 		else
 			echo "Connection\PortRangeMin=${INCOMING_PORT}" >> /config/qBittorrent/config/qBittorrent.conf
 		fi


### PR DESCRIPTION
The current documentation references WEBUI_PORT_ENV and INCOMING_PORT_ENV, but these variables are referenced in the /etc/qbittorent scripts as WEBUI_PORT, and INCOMING_PORT respectively. 

Additionally, the sed command used to replace existing persistent configs was not properly escaping the `\` in the configuration setting name. This caused invalid qbittorent.conf files to be generated when using either of the above mentioned ENV variables. This change will ensure new deployments or changes to the either variables are updated when the container starts.

**Once caveat**: If you already have an existing qbittorent.conf in your mounted volume, you will either need to edit and add the missing `\` in the setting names, or deleted the qbittorent.conf and allow it to be recreated on the next deploy