### PR TITLE
fix: openvpn/start.sh add condition to prevent appending duplicative name server entries

### DIFF
--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -144,9 +144,13 @@ for name_server_item in "${name_server_list[@]}"; do
 	# strip whitespace from start and end of lan_network_item
 	name_server_item=$(echo "${name_server_item}" | sed -e 's~^[ \t]*~~;s~[ \t]*$~~')
 
-	echo "[info] Adding ${name_server_item} to resolv.conf" | ts '%Y-%m-%d %H:%M:%.S'
-	echo "nameserver ${name_server_item}" >> /etc/resolv.conf
-
+ 	# check if name server is already defined
+ 	existing_name_servers=$(awk "/^nameserver ${name_server_item}$/" /etc/resolv.conf | wc -l)
+  
+  	if [ "$existing_name_servers" -eq 0 ]; then
+		echo "[info] Adding ${name_server_item} to resolv.conf" | ts '%Y-%m-%d %H:%M:%.S'
+		echo "nameserver ${name_server_item}" >> /etc/resolv.conf
+	fi
 done
 
 if [[ -z "${PUID}" ]]; then


### PR DESCRIPTION
This PR adds a simple check to prevent writing duplicate entries to `resolv.conf`

The issue:
When deploying this image in Kubernetes, using openVPN, in some situations the container would restart without recreating.

This would cause the `start.sh` script to run a second time, and the `resolv.conf` would be written to for a second time. Having duplicate entries in the `resolv.conf` left the container in a permanent, unrecoverable error state until the pod was manually recreated.

Node Specs:
```yaml
Capacity:
  cpu:                16
  memory:             32765604Ki
System Info:
  Kernel Version:             6.8.0-50-generic
  OS Image:                   Ubuntu 24.04.1 LTS
  Operating System:           linux
  Architecture:               amd64
  Container Runtime Version:  containerd://1.7.22
  Kubelet Version:            v1.31.1
  Kube-Proxy Version:         v1.31.1
```

Below is the deployment configuration for anyone looking to recreate this:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: qbittorrent
  name: qbittorrent
spec:
  replicas: 1
  selector:
    matchLabels:
      app: qbittorrent
  strategy: {}
  template:
    metadata:
      labels:
        app: qbittorrent
    spec:
      securityContext:
        fsGroup: 65534
        runAsUser: 0
      containers:
      - image: dyonr/qbittorrentvpn
        imagePullPolicy: IfNotPresent
        name: qbittorrentvpn
        env:
        - name: VPN_ENABLED
          value: "yes"
        - name: VPN_TYPE
          value: openvpn
        - name: LAN_NETWORK
          value: "192.168.0.0/16"
        - name: NAME_SERVERS
          value: "1.1.1.1,1.0.0.1"
        envFrom:
        - secretRef:
            name: qbittorrent-secrets # contains "VPN_USERNAME", "VPN_PASSWORD"
        securityContext:
          privileged: true  # probably not needed
          capabilities:
            add: ["NET_ADMIN", "NET_RAW"] # probably do not need `NET_RAW`
        resources: {}
        ports:
        - name: webui
          containerPort: 8080
        - name: tcplistening
          containerPort: 8999
        - name: udplistening
          containerPort: 8999
          protocol: UDP
        volumeMounts:
        - mountPath: /config
          name: config
        - mountPath: /downloads
          name: downloads

      volumes:
      - name: config
        persistentVolumeClaim:
          claimName: qbittorrent-config
      - name: downloads
        persistentVolumeClaim:
          claimName: qbittorrent-downloads
status: {}
```
